### PR TITLE
CI: lint good keys with sequoia-keyring-linter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,3 +19,8 @@ jobs:
         run: |
           ./update-keys
           git diff --exit-code
+
+      - name: Lint keys
+        run: |
+          cargo install sequoia-keyring-linter
+          sequoia-keyring-linter packager/* master/Elieux.asc master/lazka.asc


### PR DESCRIPTION
This fails if it finds SHA1, can't hurt.